### PR TITLE
fixes #19 - Workaround the ARM64 asset from gohugo

### DIFF
--- a/hugo-task/Select-HugoVersion.ps1
+++ b/hugo-task/Select-HugoVersion.ps1
@@ -23,7 +23,7 @@ function Select-HugoVersion
 
         Write-Verbose "Found release $( $release.name )"
 
-        $win64hugo = $release.assets | where { $_.name -like '*Windows*64*' }
+        $win64hugo = $release.assets | where { $_.name -like '*Windows-64*' }
 
         # extended since 0.43
         $DownloadURL = $win64hugo.browser_download_url


### PR DESCRIPTION
Fix #19 that was matching a new Asset for Windows ARM64.
Updating the `-like` to be more specific.