### PR TITLE
Remove hardcoded arguments

### DIFF
--- a/hugo-taskV2/src/HugoTask.ts
+++ b/hugo-taskV2/src/HugoTask.ts
@@ -41,7 +41,7 @@ async function run() {
         hugo.argIf(buildFuture, '--buildFuture');
 
         // implicit flags
-        hugo.line(' --i18n-warnings --path-warnings --verbose');
+        hugo.line(' --verbose');
         hugo.line(additionalArgs);
 
         await hugo.exec();


### PR DESCRIPTION
Removed hard coded arguments in the v2 task so newer versions of Hugo will work with this task again.